### PR TITLE
feat: Allow custom config with higher priority

### DIFF
--- a/charts/backstage/Chart.yaml
+++ b/charts/backstage/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: backstage
 description: A helm chart for deploying Backstage
-version: 0.1.4
+version: 0.1.5
 appVersion: "v1.7.0"
 kubeVersion: ">= 1.19.0-0"
 home: https://github.com/redhat-developer/helm-backstage

--- a/charts/backstage/README.md
+++ b/charts/backstage/README.md
@@ -1,6 +1,6 @@
 # backstage
 
-![Version: 0.1.3](https://img.shields.io/badge/Version-0.1.3-informational?style=flat-square) ![AppVersion: v1.7.0](https://img.shields.io/badge/AppVersion-v1.7.0-informational?style=flat-square)
+![Version: 0.1.5](https://img.shields.io/badge/Version-0.1.5-informational?style=flat-square) ![AppVersion: v1.7.0](https://img.shields.io/badge/AppVersion-v1.7.0-informational?style=flat-square)
 
 A helm chart for deploying Backstage
 
@@ -32,6 +32,7 @@ Replace `<RELEASE>` with the name of the Helm release that was used when install
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| additionalConfig | object | `{}` |  |
 | backstage.baseUrl | string | `""` |  |
 | backstage.catalog.locations[0].target | string | `"https://github.com/backstage/backstage/blob/master/packages/catalog-model/examples/all-components.yaml"` |  |
 | backstage.catalog.locations[0].type | string | `"url"` |  |

--- a/charts/backstage/templates/app-config.yaml
+++ b/charts/backstage/templates/app-config.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "backstage.labels" . | nindent 4 }}
 stringData:
-  app-config.yaml: |- 
+  app-config.yaml: |
     app:
       # Should be the same as backend.baseUrl when using the `app-backend` plugin.
       #baseUrl: http://{{ .Release.Name }}:7007
@@ -88,3 +88,8 @@ stringData:
       {{- with .Values.backstage.catalog }}
         {{- toYaml . | nindent 6 }}
       {{- end }}
+
+{{- if .Values.additionalConfig }}
+  additional-config.yaml: |
+    {{- toYaml .Values.additionalConfig | nindent 4 }}
+{{- end }}

--- a/charts/backstage/templates/deployment.yaml
+++ b/charts/backstage/templates/deployment.yaml
@@ -28,9 +28,17 @@ spec:
 {{- end }}
           image: "{{ template "backstage.image" .Values.image }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          command: ['node', 'packages/backend', '--config', '/config/app-config.yaml']   
+          command:
+            - node
+            - packages/backend
+            - --config
+            - /config/app-config.yaml
+            {{- if .Values.additionalConfig }}
+            - --config
+            - /config/additional-config.yaml
+            {{- end }}
           env:
-          - name: POSTGRES_ADMIN_PASSWORD  
+          - name: POSTGRES_ADMIN_PASSWORD
             valueFrom:
               secretKeyRef:
                 {{- include "backstage.postgresql.adminSecretKey" . | indent 16 }}

--- a/charts/backstage/values.schema.json
+++ b/charts/backstage/values.schema.json
@@ -893,6 +893,15 @@
                     }
                 }
             ]
+        },
+        "additionalConfig": {
+            "type": "object",
+            "default": {},
+            "title": "Additional Backstage configuration",
+            "properties": {},
+            "examples": [
+                {}
+            ]
         }
     },
     "examples": [
@@ -992,7 +1001,8 @@
                         }
                     ]
                 }
-            }
+            },
+            "additionalConfig": {}
         }
     ]
 }

--- a/charts/backstage/values.yaml
+++ b/charts/backstage/values.yaml
@@ -152,3 +152,8 @@ backstage:
       #   target: https://github.com/backstage/software-templates/blob/main/scaffolder-templates/react-ssr-template/template.yaml
       #   rules:
       #     - allow: [Template]
+
+# Provide additional configuration to Backstage.
+# This configuration takes precedence over defaults introduced by this chart.
+# Nested properties are merged with defaults.
+additionalConfig: {}


### PR DESCRIPTION
Resolves: #13 

## Description of the change

Adds `additionalConfig` value which renders a custom config file for Backstage. If defined, the config is mounted as a config file with a higher priority to backstage deployment.

## Existing or Associated Issue(s)

#13 

## Additional Information


## Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [x] JSON Schema generated.
- [x] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
